### PR TITLE
[OT171-48] Open a new screen when selecting one of the members

### DIFF
--- a/SomosMasApp/SomosMasApp.xcodeproj/project.pbxproj
+++ b/SomosMasApp/SomosMasApp.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		FB87DBCE27E3C86F001F1F97 /* ApiManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB87DBCD27E3C86F001F1F97 /* ApiManager.swift */; };
 		FBC030C927F48362006BDE08 /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC030C827F48362006BDE08 /* HomeCollectionViewCell.swift */; };
 		FBC030CB27F4837B006BDE08 /* HomeCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FBC030CA27F4837B006BDE08 /* HomeCollectionViewCell.xib */; };
+		FBCAA2B7280DF793003A72ED /* MemberDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCAA2B5280DF793003A72ED /* MemberDetailsViewController.swift */; };
+		FBCAA2B8280DF793003A72ED /* MemberDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FBCAA2B6280DF793003A72ED /* MemberDetailsViewController.xib */; };
 		FBCC597E2804AADD0041D9CA /* NewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCC597A2804AADD0041D9CA /* NewsViewController.swift */; };
 		FBCC597F2804AADD0041D9CA /* NewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FBCC597C2804AADD0041D9CA /* NewsViewController.xib */; };
 /* End PBXBuildFile section */
@@ -116,6 +118,8 @@
 		FB87DBCD27E3C86F001F1F97 /* ApiManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiManager.swift; sourceTree = "<group>"; };
 		FBC030C827F48362006BDE08 /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		FBC030CA27F4837B006BDE08 /* HomeCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HomeCollectionViewCell.xib; sourceTree = "<group>"; };
+		FBCAA2B5280DF793003A72ED /* MemberDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberDetailsViewController.swift; sourceTree = "<group>"; };
+		FBCAA2B6280DF793003A72ED /* MemberDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MemberDetailsViewController.xib; sourceTree = "<group>"; };
 		FBCC597A2804AADD0041D9CA /* NewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsViewController.swift; sourceTree = "<group>"; };
 		FBCC597C2804AADD0041D9CA /* NewsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NewsViewController.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -154,6 +158,7 @@
 		87CBCB1A27E974A900C13180 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				FBCAA2B2280DF64B003A72ED /* MemberDetails */,
 				FBCC59772804AADD0041D9CA /* News */,
 				A88F1AF927F396560062608D /* Splash */,
 				A1F1270328047A5D00657AF4 /* Nosotros */,
@@ -457,6 +462,31 @@
 			path = Service;
 			sourceTree = "<group>";
 		};
+		FBCAA2B2280DF64B003A72ED /* MemberDetails */ = {
+			isa = PBXGroup;
+			children = (
+				FBCAA2B4280DF66E003A72ED /* Controller */,
+				FBCAA2B3280DF668003A72ED /* View */,
+			);
+			path = MemberDetails;
+			sourceTree = "<group>";
+		};
+		FBCAA2B3280DF668003A72ED /* View */ = {
+			isa = PBXGroup;
+			children = (
+				FBCAA2B6280DF793003A72ED /* MemberDetailsViewController.xib */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		FBCAA2B4280DF66E003A72ED /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				FBCAA2B5280DF793003A72ED /* MemberDetailsViewController.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
 		FBCC59772804AADD0041D9CA /* News */ = {
 			isa = PBXGroup;
 			children = (
@@ -567,6 +597,7 @@
 				992878312804A9C200928413 /* NosotrosCollectionViewCell.xib in Resources */,
 				A88F1AFF27F396860062608D /* SplashViewController.xib in Resources */,
 				A1DC72B427EA260B00D9D16C /* logInView.xib in Resources */,
+				FBCAA2B8280DF793003A72ED /* MemberDetailsViewController.xib in Resources */,
 				A1F1237227FCDA8100657AF4 /* SeeMoreCollectionViewCell.xib in Resources */,
 				87CBCB2127E974A900C13180 /* SignUpViewController.xib in Resources */,
 				879483A027FD3EA10066B8F2 /* NewsCollectionViewCell.xib in Resources */,
@@ -643,6 +674,7 @@
 				995E4C6027F1F7D100632693 /* HomeViewController.swift in Sources */,
 				FB46181727EB52AD00DBE262 /* UserRegisterResponse.swift in Sources */,
 				992878362804A9CB00928413 /* NosotrosViewController.swift in Sources */,
+				FBCAA2B7280DF793003A72ED /* MemberDetailsViewController.swift in Sources */,
 				87CBCB2027E974A900C13180 /* SignUpViewController.swift in Sources */,
 				992878352804A9CB00928413 /* NosotrosCollectionViewCell.swift in Sources */,
 				A8C466F427EAD3AF00A2DDBE /* LogInViewModel.swift in Sources */,

--- a/SomosMasApp/SomosMasApp/App/Shared/Modules/MemberDetails/Controller/MemberDetailsViewController.swift
+++ b/SomosMasApp/SomosMasApp/App/Shared/Modules/MemberDetails/Controller/MemberDetailsViewController.swift
@@ -1,0 +1,31 @@
+//
+//  MemberDetailsViewController.swift
+//  SomosMasApp
+//
+//  Created by Braian Theiler on 18/04/2022.
+//
+
+import UIKit
+
+class MemberDetailsViewController: UIViewController {
+    
+    @IBOutlet weak var imageMember: UIImageView!
+    @IBOutlet weak var memberName: UILabel!
+    @IBOutlet weak var jobTitle: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationController?.topViewController?.title = "Member Details"
+    }
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/SomosMasApp/SomosMasApp/App/Shared/Modules/MemberDetails/View/MemberDetailsViewController.xib
+++ b/SomosMasApp/SomosMasApp/App/Shared/Modules/MemberDetails/View/MemberDetailsViewController.xib
@@ -21,7 +21,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" highlighted="YES" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="li9-Rj-jqQ">
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="li9-Rj-jqQ">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="250" id="bcg-bt-sw3"/>

--- a/SomosMasApp/SomosMasApp/App/Shared/Modules/MemberDetails/View/MemberDetailsViewController.xib
+++ b/SomosMasApp/SomosMasApp/App/Shared/Modules/MemberDetails/View/MemberDetailsViewController.xib
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MemberDetailsViewController" customModule="SomosMasApp" customModuleProvider="target">
+            <connections>
+                <outlet property="imageMember" destination="li9-Rj-jqQ" id="TzQ-mu-Vde"/>
+                <outlet property="jobTitle" destination="kdq-p6-f8W" id="tpw-LA-MVk"/>
+                <outlet property="memberName" destination="sd6-d7-12h" id="3jg-My-EWn"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" highlighted="YES" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="li9-Rj-jqQ">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="250" id="bcg-bt-sw3"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nombre" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sd6-d7-12h">
+                    <rect key="frame" x="0.0" y="270" width="414" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Puesto" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kdq-p6-f8W">
+                    <rect key="frame" x="0.0" y="311" width="414" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="li9-Rj-jqQ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="1F6-qQ-m9m"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="kdq-p6-f8W" secondAttribute="trailing" id="3Rr-U1-R0E"/>
+                <constraint firstItem="sd6-d7-12h" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Db3-1m-Kpd"/>
+                <constraint firstItem="kdq-p6-f8W" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Fj7-e2-hQd"/>
+                <constraint firstItem="kdq-p6-f8W" firstAttribute="top" secondItem="sd6-d7-12h" secondAttribute="bottom" constant="20" id="OcA-pY-4N1"/>
+                <constraint firstItem="li9-Rj-jqQ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="SUA-uz-FdJ"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="sd6-d7-12h" secondAttribute="trailing" id="ZPE-Ys-xXA"/>
+                <constraint firstItem="li9-Rj-jqQ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="jj8-Xc-PV3"/>
+                <constraint firstItem="sd6-d7-12h" firstAttribute="top" secondItem="li9-Rj-jqQ" secondAttribute="bottom" constant="20" id="rnw-uX-n6q"/>
+            </constraints>
+            <point key="canvasLocation" x="137.68115942028987" y="75.669642857142847"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/SomosMasApp/SomosMasApp/App/Shared/Modules/Nosotros/ViewController/NosotrosViewController.swift
+++ b/SomosMasApp/SomosMasApp/App/Shared/Modules/Nosotros/ViewController/NosotrosViewController.swift
@@ -72,6 +72,9 @@ class NosotrosViewController: UIViewController, UICollectionViewDelegate, UIColl
         return CGSize(width: width, height: width)
     }
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.navigationController?.pushViewController(MemberDetailsViewController(), animated: true)
+    }
     
     /*
     // MARK: - Navigation


### PR DESCRIPTION
In this functionality, what was requested was done and the view was also made, leaving the image, the name of the member and the position he has. At this moment the view is empty because the functionality of completing the detail of the members is the objective of another user story.

Demo: 

https://user-images.githubusercontent.com/74666277/164105222-ba5c635c-7556-4712-b52a-eef1da32199f.mov

Jira Ticket -> [OT171-48] (https://alkemy-labs.atlassian.net/browse/OT171-48)
